### PR TITLE
Tests related to many to many relationships used via exclude queries

### DIFF
--- a/cachalot/tests/migrations/0002_auto_20150416_0933.py
+++ b/cachalot/tests/migrations/0002_auto_20150416_0933.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cachalot', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='TestOne',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(max_length=20)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='TestThese',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(max_length=20)),
+            ],
+        ),
+        migrations.AddField(
+            model_name='testone',
+            name='have_lots_of_these',
+            field=models.ManyToManyField(to='cachalot.TestThese', null=True, blank=True),
+        ),
+    ]

--- a/cachalot/tests/models.py
+++ b/cachalot/tests/models.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 from django.conf import settings
 from django.db.models import (
-    Model, CharField, ForeignKey, BooleanField, DateField, DateTimeField)
+    Model, CharField, ForeignKey, BooleanField, DateField, DateTimeField, ManyToManyField)
 
 
 class Test(Model):
@@ -32,3 +32,12 @@ class TestChild(TestParent):
 
     class Meta(object):
         app_label = 'cachalot'
+
+
+class TestOne(Model):
+    name = CharField(max_length=20)
+    have_lots_of_these = ManyToManyField('TestThese', blank=True, null=True)
+
+
+class TestThese(Model):
+    name = CharField(max_length=20)


### PR DESCRIPTION
Hi Bertrand,

I was experimenting with using cachalot on a big django project that we have. It looks great. 

I came across a problem highlighted by a unit test fail in our project when I had cachalot installed which I think relates to the use of exclude queries with many-to-many related models. I believe the cache is being used when in fact it shouldn't be. I have written a couple of unit tests in write.py (test_clear_with_filters and test_clear_with_excludes) which basically test for the same thing but in one case using .filter() queries (which works fine) and in the other case using .exclude() queries (the tests fail). Note that the failing tests can be made to pass by explicitly calling hub.save() after line 884. I'm not sure what the underlying cause is - it might well be something obvious to you but I thought it would be worth getting to the bottom of before we experiment further with cachalot.

Best wishes,
Helen Warren.
