### PR TITLE
Handle None response from django-redis

### DIFF
--- a/cachalot/monkey_patch.py
+++ b/cachalot/monkey_patch.py
@@ -55,6 +55,9 @@ def _get_result_or_execute_query(execute_query_func, cache_key,
     cache = cachalot_caches.get_cache()
     data = cache.get_many(table_cache_keys + [cache_key])
 
+    if data == None:
+        return execute_query_func()
+
     new_table_cache_keys = set(table_cache_keys)
     new_table_cache_keys.difference_update(data)
 

--- a/cachalot/panels.py
+++ b/cachalot/panels.py
@@ -47,8 +47,9 @@ class CachalotPanel(Panel):
             model_cache_keys = dict(
                 [(_get_table_cache_key(db_alias, model._meta.db_table), model)
                  for model in models])
-            for cache_key, timestamp in cache.get_many(
-                    model_cache_keys.keys()).items():
+            cached_items = cache.get_many(model_cache_keys.keys())
+            cached_items = cached_items if not cached_items == None else {}
+            for cache_key, timestamp in .items():
                 invalidation = datetime.fromtimestamp(timestamp)
                 model = model_cache_keys[cache_key]
                 data[db_alias].append(

--- a/cachalot/panels.py
+++ b/cachalot/panels.py
@@ -49,7 +49,7 @@ class CachalotPanel(Panel):
                  for model in models])
             cached_items = cache.get_many(model_cache_keys.keys())
             cached_items = cached_items if not cached_items == None else {}
-            for cache_key, timestamp in .items():
+            for cache_key, timestamp in cached_items.items():
                 invalidation = datetime.fromtimestamp(timestamp)
                 model = model_cache_keys[cache_key]
                 data[db_alias].append(

--- a/cachalot/panels.py
+++ b/cachalot/panels.py
@@ -47,8 +47,7 @@ class CachalotPanel(Panel):
             model_cache_keys = dict(
                 [(_get_table_cache_key(db_alias, model._meta.db_table), model)
                  for model in models])
-            cached_items = cache.get_many(model_cache_keys.keys())
-            cached_items = cached_items if not cached_items == None else {}
+            cached_items = cache.get_many(model_cache_keys.keys()) or {}
             for cache_key, timestamp in cached_items.items():
                 invalidation = datetime.fromtimestamp(timestamp)
                 model = model_cache_keys[cache_key]

--- a/cachalot/transaction.py
+++ b/cachalot/transaction.py
@@ -21,7 +21,9 @@ class AtomicCache(dict):
                 data[k] = self[k]
         missing_keys = set(keys)
         missing_keys.difference_update(data)
-        data.update(self.parent_cache.get_many(missing_keys))
+        missing_items = self.parent_cache.get_many(missing_keys)
+        missing_items = missing_items if not missing_items == None else {}
+        data.update(missing_items)
         return data
 
     def set_many(self, data, timeout):

--- a/cachalot/transaction.py
+++ b/cachalot/transaction.py
@@ -21,8 +21,7 @@ class AtomicCache(dict):
                 data[k] = self[k]
         missing_keys = set(keys)
         missing_keys.difference_update(data)
-        missing_items = self.parent_cache.get_many(missing_keys)
-        missing_items = missing_items if not missing_items == None else {}
+        missing_items = self.parent_cache.get_many(missing_keys) or {}
         data.update(missing_items)
         return data
 


### PR DESCRIPTION
After wrestling with the [solution](https://groups.google.com/forum/#!topic/django-cachalot/5T4UCs3R_Rk) we discussed the other day, I found that having django-redis return an empty dict when exceptions are ignored (in django-redis) causes several issues on the django orm and django rest framework side. I found that the easiest solution was to handle a `None` response in django-cachalot itself, executing the query upon receiving said response. Let me know what you think.