### PR TITLE
Improve django 1.8+ support by getting cache appropriately.

### DIFF
--- a/cachalot/cache.py
+++ b/cachalot/cache.py
@@ -3,8 +3,13 @@
 from __future__ import unicode_literals
 from threading import local
 
-# TODO: Replace with caches[CACHALOT_CACHE] when we drop Django 1.6 support.
-from django.core.cache import get_cache as get_django_cache
+import django
+
+if django.VERSION >= (1,7):
+    from django.core.cache import caches
+    get_django_cache = lambda cache_alias: caches[cache_alias]
+else:
+    from django.core.cache import get_cache as get_django_cache
 
 from .settings import cachalot_settings
 from .transaction import AtomicCache


### PR DESCRIPTION
This change gets rid of deprecation warnings related to cache retrieval. Specifically, it addresses this warning, while remaining compatible with Django 1.6:

```
cachalot/cache.py:32: RemovedInDjango19Warning: 'get_cache' is deprecated in favor of 'caches'.
  return get_django_cache(cache_alias)
```