### PR TITLE
Switched to new application loading system

### DIFF
--- a/cachalot/panels.py
+++ b/cachalot/panels.py
@@ -5,9 +5,9 @@ from collections import defaultdict
 from datetime import datetime
 
 from debug_toolbar.panels import Panel
+from django.apps import apps
 from django.conf import settings
 from django.core.cache import cache
-from django.db.models.loading import get_models
 from django.utils.translation import ugettext_lazy as _
 from django.utils.timesince import timesince
 
@@ -41,7 +41,7 @@ class CachalotPanel(Panel):
         self.collect_invalidations()
 
     def collect_invalidations(self):
-        models = get_models()
+        models = apps.get_models()
         data = defaultdict(list)
         for db_alias in settings.DATABASES:
             model_cache_keys = dict(


### PR DESCRIPTION
In Django 1.7 new [app-loading system](https://docs.djangoproject.com/en/1.7/releases/1.7/#app-loading-refactor) was introduced. The old way is deprecated and produces warning in Django 1.8:

````
.../lib/python3.4/importlib/_bootstrap.py:321: RemovedInDjango19Warning: The utilities in django.db.models.loading are deprecated in favor of the new application loading system.
  return f(*args, **kwds)
````