### PR TITLE
Add django-pylibmc backend

### DIFF
--- a/cachalot/apps.py
+++ b/cachalot/apps.py
@@ -29,6 +29,7 @@ VALID_CACHE_BACKENDS = {
     'django_redis.cache.RedisCache',
     'django.core.cache.backends.memcached.MemcachedCache',
     'django.core.cache.backends.memcached.PyLibMCCache',
+    'django_pylibmc.memcached.PyLibMCCache',
 }
 
 


### PR DESCRIPTION
Include django-pylibmc as a valid cache backend.  This is useful for accessing memcached servers using environment variables necessary for logging into memcached cloud services.