### PR TITLE
Cache error when mixing string/unicode params in query

### DIFF
--- a/cachalot/tests/read.py
+++ b/cachalot/tests/read.py
@@ -84,6 +84,17 @@ class ReadTestCase(TransactionTestCase):
         self.assertEqual(data2, data1)
         self.assertEqual(data2, self.t1)
 
+    def test_get_string_unicode(self):
+        with self.assertNumQueries(1):
+            data1 = Test.objects.get(name='test1')
+        with self.assertNumQueries(0):
+            data2 = Test.objects.get(name=str('test1'))
+        with self.assertNumQueries(0):
+            data3 = Test.objects.get(name=unicode('test1'))
+        self.assertEqual(data1, self.t1)
+        self.assertEqual(data2, self.t1)
+        self.assertEqual(data3, self.t1)
+
     def test_first(self):
         with self.assertNumQueries(1):
             self.assertEqual(Test.objects.filter(name='bad').first(), None)
@@ -155,6 +166,17 @@ class ReadTestCase(TransactionTestCase):
                                              name='user'))
         self.assertListEqual(data2, data1)
         self.assertListEqual(data2, [])
+
+    def test_filter_string_unicode(self):
+        with self.assertNumQueries(1):
+            data1 = list(Test.objects.filter(name='test1'))
+        with self.assertNumQueries(0):
+            data2 = list(Test.objects.filter(name=str('test1')))
+        with self.assertNumQueries(0):
+            data3 = list(Test.objects.filter(name=unicode('test1')))
+        self.assertEqual(data1, [self.t1])
+        self.assertEqual(data2, [self.t1])
+        self.assertEqual(data3, [self.t1])
 
     def test_exclude(self):
         with self.assertNumQueries(1):


### PR DESCRIPTION
This bug was really hard to spot. It happens when doing a `get()` or `filter()` for the same `CharField` but mixing the types `str` and `unicode`. The method `get_query_cache_key()` will convert the query params to string:

```
default:SELECT [skipped...] WHERE "cachalot_test"."name" = %s:(u'test1',)
```

```
default:SELECT [skipped...] WHERE "cachalot_test"."name" = %s:('test1',)
```
As you can see, the representation of the `unicode` type has a `u` before, which the string doesn't. This means there are two different keys cached for the same query.

I have attached a test showing the bug. Any idea which is the best way to deal with this edge case?