### PR TITLE
Unicode encode fix

### DIFF
--- a/cachalot/monkey_patch.py
+++ b/cachalot/monkey_patch.py
@@ -1,4 +1,4 @@
-# coding: utf-8
+# -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
 from collections import Iterable
@@ -18,7 +18,6 @@ from .settings import cachalot_settings
 from .utils import (
     _get_query_cache_key, _get_table_cache_keys, _get_tables_from_sql,
     _invalidate_table, UncachableQuery, TUPLE_OR_LIST)
-
 
 WRITE_COMPILERS = (SQLInsertCompiler, SQLUpdateCompiler, SQLDeleteCompiler)
 
@@ -107,7 +106,9 @@ def _patch_cursor():
             if getattr(cursor.db, 'raw', True) \
                     and cachalot_settings.CACHALOT_INVALIDATE_RAW:
                 sql = sql.lower()
-                if 'update' in sql or 'insert' in sql or 'delete' in sql:
+                if not isinstance(sql, unicode):
+                    sql = unicode(sql, 'utf-8')
+                if unicode('update') in sql or unicode('insert') in sql or unicode('delete') in sql:
                     tables = _get_tables_from_sql(cursor.db, sql)
                     invalidate(*tables, db_alias=cursor.db.alias)
             return out


### PR DESCRIPTION
This is a fix for issue #50. Essentially just checks the ```sql``` object and if it is not a unicode object, it will encode it into a unicode object. This fix allows for better backwards compatibility with Python2.7 code, where objects of Type str are encoded in ascii.