### PR TITLE
Add support for django.db.backends.postgresql engine

### DIFF
--- a/cachalot/apps.py
+++ b/cachalot/apps.py
@@ -1,3 +1,4 @@
+from django import VERSION as django_version
 from django.apps import AppConfig
 from django.conf import settings
 from django.core.checks import register, Tags, Error, Warning
@@ -21,6 +22,9 @@ VALID_DATABASE_ENGINES = {
     'transaction_hooks.backends.postgresql_psycopg2',
     'transaction_hooks.backends.mysql',
 }
+
+if django_version[:2] >= (1, 9):
+    VALID_DATABASE_ENGINES.add('django.db.backends.postgresql')
 
 
 VALID_CACHE_BACKENDS = {

--- a/settings.py
+++ b/settings.py
@@ -6,13 +6,18 @@ import os
 from django import VERSION as django_version
 
 
+if django_version[:2] >= (1, 9):
+    POSTGRES_ENGINE = 'django.db.backends.postgresql'
+else:
+    POSTGRES_ENGINE = 'django.db.backends.postgresql_psycopg2'
+
 DATABASES = {
     'sqlite3': {
         'ENGINE': 'django.db.backends.sqlite3',
         'NAME': 'cachalot.sqlite3',
     },
     'postgresql': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'ENGINE': POSTGRES_ENGINE,
         'NAME': 'cachalot',
         'USER': 'cachalot',
     },


### PR DESCRIPTION
This is the new name in 1.9, and the old django.db.backends.postgresql_psycopg2
is left in for backwards compatibility.

Docs on this available [here](https://docs.djangoproject.com/en/1.9/releases/1.9/#database-backends).