### PR TITLE
Fixed django>=1.11 support.

### DIFF
--- a/cachalot/utils.py
+++ b/cachalot/utils.py
@@ -162,7 +162,7 @@ def _get_tables(query, db_alias):
     subquery_constraints = _find_subqueries(query.where.children)
     for subquery in subquery_constraints:
         tables.update(_get_tables(subquery, db_alias))
-    if query.extra_select or hasattr(query, 'subquery') \
+    if query.extra_select or (hasattr(query, 'subquery') and query.subquery) \
             or any(c.__class__ is ExtraWhere for c in query.where.children):
         sql = query.get_compiler(db_alias).as_sql()[0].lower()
         additional_tables = _get_tables_from_sql(connections[db_alias], sql)


### PR DESCRIPTION
Since Django 1.11 the ``query`` argument of the SQLCompiler constructor has always a ``subquery`` property, in fact if the SQL query has no real sub query it is set to False.
As a result, the test done by Django-cachalot in the ``_get_tables`` function is no more accurate and cause a dramatic slow down on 1.11 django installs.
This fix should be backwards compatible with older versions of Django.