### PR TITLE
Functionality to disable django-cachalot during a thread

### DIFF
--- a/cachalot/monkey_patch.py
+++ b/cachalot/monkey_patch.py
@@ -40,10 +40,13 @@ class Disabled:
             with DISABLE_CACHING:
                 DISABLE_CACHING.do_not_invalidate()  # Optional Line, will not invalidate after the with
 
+                # Optional line that allows you to change the cache and db aliases used when invalidating.
+                DISABLE_CACHING.set_aliases(cache_alias='default', db_alias='default')
+
                 # Code to run while the cache is disabled
 
 
-        Example 3:
+        Example 2:
             from cachalot.monkey_patch import DISABLE_CACHING
 
             try:
@@ -51,8 +54,9 @@ class Disabled:
                 # Code to run while the cache is disabled
 
             finally:
-                # invalidate_cache by default is True
-                DISABLE_CACHING.disable(invalidate_cache=False)
+                # invalidate_cache is only needed if you do not want to invalidate the cache.
+                # Also allow you to change the cache and db aliases used when invalidating.
+                DISABLE_CACHING.disable(invalidate_cache=False, cache_alias='default', db_alias='default')
     """
     def __init__(self):
         self.threads = frozenset()

--- a/cachalot/monkey_patch.py
+++ b/cachalot/monkey_patch.py
@@ -2,7 +2,6 @@
 
 from __future__ import unicode_literals
 from collections import Iterable
-from threading import get_ident
 from time import time
 
 from django.db.backends.utils import CursorWrapper
@@ -12,7 +11,12 @@ from django.db.models.sql.compiler import (
     SQLCompiler, SQLInsertCompiler, SQLUpdateCompiler, SQLDeleteCompiler,
 )
 from django.db.transaction import Atomic, get_connection
-from django.utils.six import binary_type, wraps
+from django.utils.six import binary_type, wraps, PY3
+
+if PY3:
+    from threading import get_ident
+else:
+    from thread import get_ident
 
 from .api import invalidate
 from .cache import cachalot_caches

--- a/cachalot/tests/__init__.py
+++ b/cachalot/tests/__init__.py
@@ -12,7 +12,7 @@ from .api import APITestCase, CommandTestCase
 from .signals import SignalsTestCase
 from .postgres import PostgresReadTestCase
 from .debug_toolbar import DebugToolbarTestCase
-from .disabling import DisablingTestCase, DisablingMultiDatabaseTestCase
+from .disabling import DisablingTestCase, DisablingMultiDatabaseTestCase, DisablingMultiCacheTestCase
 
 
 @receiver(setting_changed)

--- a/cachalot/tests/__init__.py
+++ b/cachalot/tests/__init__.py
@@ -12,6 +12,7 @@ from .api import APITestCase, CommandTestCase
 from .signals import SignalsTestCase
 from .postgres import PostgresReadTestCase
 from .debug_toolbar import DebugToolbarTestCase
+from .disabling import DisablingTestCase
 
 
 @receiver(setting_changed)

--- a/cachalot/tests/__init__.py
+++ b/cachalot/tests/__init__.py
@@ -12,7 +12,7 @@ from .api import APITestCase, CommandTestCase
 from .signals import SignalsTestCase
 from .postgres import PostgresReadTestCase
 from .debug_toolbar import DebugToolbarTestCase
-from .disabling import DisablingTestCase
+from .disabling import DisablingTestCase, DisablingMultiDatabaseTestCase
 
 
 @receiver(setting_changed)

--- a/cachalot/tests/disabling.py
+++ b/cachalot/tests/disabling.py
@@ -1,0 +1,162 @@
+# coding: utf-8
+
+from __future__ import unicode_literals
+import datetime
+from unittest import skipIf, skipUnless
+from uuid import UUID
+from decimal import Decimal
+
+from django import VERSION as django_version
+from django.contrib.auth.models import Group, Permission, User
+from django.contrib.contenttypes.models import ContentType
+from django.core.cache import cache
+from django.db import connection, transaction
+from django.db.models import Count
+from django.db.models.expressions import RawSQL
+from django.db.transaction import TransactionManagementError
+from django.test import (
+    TransactionTestCase, skipUnlessDBFeature, override_settings)
+from pytz import UTC
+
+from ..monkey_patch import DISABLE_CACHING
+from ..settings import cachalot_settings
+from ..utils import UncachableQuery
+from .models import Test, TestChild, TestParent
+from .test_utils import TestUtilsMixin
+
+
+class DisablingTestCase(TestUtilsMixin, TransactionTestCase):
+    """
+    Test the number of queries run while switching between
+    caching being enabled and disabled.
+
+    Test both forms of use (with statement and try finally).
+
+    Test that things invalidate after enabling.
+
+    Test that things are still cached if we don't invalidate after
+    enabling.
+
+    Make sure that the sql gets run on the line where we create it
+    so that sql runs exactly where the test specifies the query.
+    This way we don't have issues where an sql query doesn't get
+    executed until you use it in an assert test.
+    """
+
+    def setUp(self):
+        super(DisablingTestCase, self).setUp()
+
+        self.group = Group.objects.create(name='test_group')
+        self.group__permissions = list(Permission.objects.all()[:3])
+        self.group.permissions.add(*self.group__permissions)
+        self.user = User.objects.create_user('user')
+        self.user__permissions = list(Permission.objects.all()[3:6])
+        self.user.groups.add(self.group)
+        self.user.user_permissions.add(*self.user__permissions)
+        self.admin = User.objects.create_superuser('admin', 'admin@test.me',
+                                                   'password')
+        self.t1__permission = (Permission.objects.order_by('?')
+                               .select_related('content_type')[0])
+        self.t1 = Test.objects.create(
+            name='test1', owner=self.user,
+            date='1789-07-14', datetime='1789-07-14T16:43:27',
+            permission=self.t1__permission)
+        self.t2 = Test.objects.create(
+            name='test2', owner=self.admin, public=True,
+            date='1944-06-06', datetime='1944-06-06T06:35:00')
+
+    def test_read_disabling_using_with_stmt(self):
+        with self.assertNumQueries(1):
+            n1 = bool(Test.objects.exists())  # Force the query to run
+        # Caching disabled so this query shouldn't be cached
+        with DISABLE_CACHING:
+            with self.assertNumQueries(1):
+                n2 = bool(Test.objects.exists())  # Force the query to run
+
+    def test_read_toggle_disabling_using_with_stmt(self):
+        with self.assertNumQueries(1):
+            n1 = bool(Test.objects.exists())  # Force the query to run
+        # Disable the cache
+        with DISABLE_CACHING:
+            with self.assertNumQueries(1):
+                n2 = bool(Test.objects.exists())  # Force the query to run
+        # Caching enabled but invalidating has run
+        with self.assertNumQueries(1):
+            n3 = bool(Test.objects.exists())  # Force the query to run
+        with self.assertNumQueries(0):
+            n4 = bool(Test.objects.exists())  # Force the query to run
+
+    def test_read_toggle_disabling_without_invalidating_using_with_stmt(self):
+        with self.assertNumQueries(1):
+            n1 = bool(Test.objects.exists())  # Force the query to run
+        # Disable the cache
+        with DISABLE_CACHING:
+            DISABLE_CACHING.do_not_invalidate()
+            with self.assertNumQueries(1):
+                n2 = bool(Test.objects.exists())  # Force the query to run
+        # Caching enabled without invalidating so this query should be cached
+        with self.assertNumQueries(0):
+            n3 = bool(Test.objects.exists())  # Force the query to run
+
+    def test_read_disabling_using_try_finally(self):
+        with self.assertNumQueries(1):
+            n1 = bool(Test.objects.exists())  # Force the query to run
+        blew_up = False
+        err = None
+        # Caching disabled so this query shouldn't be cached
+        try:
+            DISABLE_CACHING.enable()
+            with self.assertNumQueries(1):
+                n2 = bool(Test.objects.exists())  # Force the query to run
+        except Exception as err:
+            blew_up = True
+        finally:
+            DISABLE_CACHING.disable()
+        self.assertFalse(blew_up, msg='Unexpected Exception Occurred: {0}'.format(err))
+
+
+    def test_read_toggle_disabling_using_try_finally(self):
+        with self.assertNumQueries(1):
+            n1 = bool(Test.objects.exists())  # Force the query to run
+        blew_up = False
+        err = None
+        # Disable the cache
+        try:
+            DISABLE_CACHING.enable()
+            with self.assertNumQueries(1):
+                n2 = bool(Test.objects.exists())  # Force the query to run
+        except Exception as err:
+            blew_up = True
+        finally:
+            DISABLE_CACHING.disable()
+        self.assertFalse(blew_up, msg='Unexpected Exception Occurred: {0}'.format(err))
+        # Caching enabled but invalidating has run
+        with self.assertNumQueries(1):
+            n3 = bool(Test.objects.exists())  # Force the query to run
+        with self.assertNumQueries(0):
+            n4 = bool(Test.objects.exists())  # Force the query to run
+
+    def test_read_toggle_disabling_without_invalidating_using_try_finally(self):
+        with self.assertNumQueries(1):
+            n1 = bool(Test.objects.exists())  # Force the query to run
+        blew_up = False
+        err = None
+        # Disable the cache
+        try:
+            DISABLE_CACHING.enable()
+            with self.assertNumQueries(1):
+                n2 = bool(Test.objects.exists())  # Force the query to run
+        except Exception as err:
+            blew_up = True
+        finally:
+            DISABLE_CACHING.disable(invalidate_cache=False)
+        self.assertFalse(blew_up, msg='Unexpected Exception Occurred: {0}'.format(err))
+        # Caching enabled without invalidating so this query should be cached
+        with self.assertNumQueries(0):
+            n3 = bool(Test.objects.exists())  # Force the query to run
+
+
+
+# TODO: Create test that reads and then disables and writes and then turns off the disable without
+# invalidating and reads the cached value then invalidate and read the new value
+

--- a/cachalot/tests/disabling.py
+++ b/cachalot/tests/disabling.py
@@ -67,172 +67,280 @@ class DisablingTestCase(TestUtilsMixin, TransactionTestCase):
 
     def test_read_disabling_using_with_stmt(self):
         with self.assertNumQueries(1):
-            n1 = bool(Test.objects.exists())  # Force the query to run
-        # Caching disabled so this query shouldn't be cached
-        with DISABLE_CACHING:
-            with self.assertNumQueries(1):
-                n2 = bool(Test.objects.exists())  # Force the query to run
-
-    def test_read_toggle_disabling_using_with_stmt(self):
-        with self.assertNumQueries(1):
-            n1 = bool(Test.objects.exists())  # Force the query to run
+            bool(Test.objects.exists())  # Force the query to run
         # Disable the cache
         with DISABLE_CACHING:
             with self.assertNumQueries(1):
-                n2 = bool(Test.objects.exists())  # Force the query to run
+                bool(Test.objects.exists())  # Force the query to run
         # Caching enabled, invalidating has run
         with self.assertNumQueries(1):
-            n3 = bool(Test.objects.exists())  # Force the query to run
+            bool(Test.objects.exists())  # Force the query to run
         with self.assertNumQueries(0):
-            n4 = bool(Test.objects.exists())  # Force the query to run
+            bool(Test.objects.exists())  # Force the query to run
 
-    def test_read_toggle_disabling_without_invalidating_using_with_stmt(self):
+    def test_read_disabling_without_invalidating_using_with_stmt(self):
         with self.assertNumQueries(1):
-            n1 = bool(Test.objects.exists())  # Force the query to run
+            bool(Test.objects.exists())  # Force the query to run
         # Disable the cache
         with DISABLE_CACHING:
             DISABLE_CACHING.do_not_invalidate()
             with self.assertNumQueries(1):
-                n2 = bool(Test.objects.exists())  # Force the query to run
+                bool(Test.objects.exists())  # Force the query to run
         # Caching enabled without invalidating so this query should be cached
         with self.assertNumQueries(0):
-            n3 = bool(Test.objects.exists())  # Force the query to run
+            bool(Test.objects.exists())  # Force the query to run
 
     def test_read_disabling_using_try_finally(self):
         with self.assertNumQueries(1):
-            n1 = bool(Test.objects.exists())  # Force the query to run
+            bool(Test.objects.exists())  # Force the query to run
         blew_up = False
-        err = None
-        # Caching disabled so this query shouldn't be cached
-        try:
-            DISABLE_CACHING.enable()
-            with self.assertNumQueries(1):
-                n2 = bool(Test.objects.exists())  # Force the query to run
-        except Exception as err:
-            blew_up = True
-        finally:
-            DISABLE_CACHING.disable()
-        self.assertFalse(blew_up, msg='Unexpected Exception Occurred: {0}'.format(err))
-
-    def test_read_toggle_disabling_using_try_finally(self):
-        with self.assertNumQueries(1):
-            n1 = bool(Test.objects.exists())  # Force the query to run
-        blew_up = False
-        err = None
+        error_message = None
         # Disable the cache
         try:
             DISABLE_CACHING.enable()
             with self.assertNumQueries(1):
-                n2 = bool(Test.objects.exists())  # Force the query to run
-        except Exception as err:
+                bool(Test.objects.exists())  # Force the query to run
+        except Exception as err:  # In python 3 err is deleted after this block
             blew_up = True
+            error_message = err
         finally:
             DISABLE_CACHING.disable()
-        self.assertFalse(blew_up, msg='Unexpected Exception Occurred: {0}'.format(err))
+        self.assertFalse(blew_up, msg='Unexpected Exception Occurred: {0}'.format(error_message))
         # Caching enabled but invalidating has run
         with self.assertNumQueries(1):
-            n3 = bool(Test.objects.exists())  # Force the query to run
+            bool(Test.objects.exists())  # Force the query to run
         with self.assertNumQueries(0):
-            n4 = bool(Test.objects.exists())  # Force the query to run
+            bool(Test.objects.exists())  # Force the query to run
 
-    def test_read_toggle_disabling_without_invalidating_using_try_finally(self):
+    def test_read_disabling_without_invalidating_using_try_finally(self):
         with self.assertNumQueries(1):
-            n1 = bool(Test.objects.exists())  # Force the query to run
+            bool(Test.objects.exists())  # Force the query to run
         blew_up = False
-        err = None
+        error_message = None
         # Disable the cache
         try:
             DISABLE_CACHING.enable()
             with self.assertNumQueries(1):
-                n2 = bool(Test.objects.exists())  # Force the query to run
-        except Exception as err:
+                bool(Test.objects.exists())  # Force the query to run
+        except Exception as err:  # In python 3 err is deleted after this block
             blew_up = True
+            error_message = err
         finally:
             DISABLE_CACHING.disable(invalidate_cache=False)
-        self.assertFalse(blew_up, msg='Unexpected Exception Occurred: {0}'.format(err))
+        self.assertFalse(blew_up, msg='Unexpected Exception Occurred: {0}'.format(error_message))
         # Caching enabled without invalidating so this query should be cached
         with self.assertNumQueries(0):
-            n3 = bool(Test.objects.exists())  # Force the query to run
+            bool(Test.objects.exists())  # Force the query to run
 
     def test_write_disabling_using_with_stmt(self):
-        data1 = Test.objects.get(name='test1')
-        data1_name = data1.name  # Force the query to run
+        with self.assertNumQueries(1):
+            data1 = Test.objects.get(name='test1')
         # Disable the cache
         with DISABLE_CACHING:
-            with self.assertNumQueries(1):
+            with self.assertNumQueries(2 if self.is_sqlite else 1):
                 data1.name = 'test1a'
                 data1.save()
         # Caching enabled, invalidating has run
         with self.assertNumQueries(1):
-            data2 = Test.objects.get(name='test1a')
-            data2_name = data2.name  # Force the query to run
+            Test.objects.get(name='test1a')
         with self.assertNumQueries(0):
-            data3 = Test.objects.get(name='test1a')
-            data3_name = data3.name  # Force the query to run
-        # Reset the name to test1
-        data1.name = 'test1'
-        data1.save()
+            Test.objects.get(name='test1a')
 
     # HOPEFULLY NO ONE EVER DOES THIS IN PRODUCTION CODE.
     def test_write_disabling_without_invalidating_using_with_stmt(self):
-        data1 = Test.objects.get(name='test1')
-        data1_name = data1.name  # Force the query to run
+        with self.assertNumQueries(1):
+            data1 = Test.objects.get(name='test1')
         # Disable the cache
         with DISABLE_CACHING:
             DISABLE_CACHING.do_not_invalidate()
-            with self.assertNumQueries(1):
+            with self.assertNumQueries(2 if self.is_sqlite else 1):
                 data1.name = 'test1a'
                 data1.save()
         # Caching enabled without invalidating so this query should
         # be cached even though the object is no longer named test1.
         with self.assertNumQueries(0):
-            data2 = Test.objects.get(name='test1')
-            data2_name = data2.name  # Force the query to run
+            Test.objects.get(name='test1')
         with self.assertNumQueries(1):
-            data3 = Test.objects.get(name='test1a')
-            data3_name = data3.name  # Force the query to run
-        data1.name = 'test1'
-        data1.save()
+            Test.objects.get(name='test1a')
 
     def test_write_disabling_using_try_finally(self):
-        data1 = Test.objects.get(name='test1')
-        data1_name = data1.name  # Force the query to run
+        with self.assertNumQueries(1):
+            data1 = Test.objects.get(name='test1')
         blew_up = False
-        err = None
+        error_message = None
         # Disable the cache
         try:
             DISABLE_CACHING.enable()
-            with self.assertNumQueries(1):
+            with self.assertNumQueries(2 if self.is_sqlite else 1):
                 data1.name = 'test1a'
                 data1.save()
-        except Exception as err:
+        except Exception as err:  # In python 3 err is deleted after this block
             blew_up = True
+            error_message = err
         finally:
             DISABLE_CACHING.disable()
-        self.assertFalse(blew_up, msg='Unexpected Exception Occurred: {0}'.format(err))
+        self.assertFalse(blew_up, msg='Unexpected Exception Occurred: {0}'.format(error_message))
         # Caching enabled, invalidating has run
         with self.assertNumQueries(1):
-            data2 = Test.objects.get(name='test1a')
-            data2_name = data2.name  # Force the query to run
+            Test.objects.get(name='test1a')
         with self.assertNumQueries(0):
-            data3 = Test.objects.get(name='test1a')
-            data3_name = data3.name  # Force the query to run
-        # Reset the name to test1
-        data1.name = 'test1'
-        data1.save()
+            Test.objects.get(name='test1a')
 
     # HOPEFULLY NO ONE EVER DOES THIS IN PRODUCTION CODE.
     def test_write_disabling_without_invalidating_using_try_finally(self):
         data1 = Test.objects.get(name='test1')
-        data1_name = data1.name  # Force the query to run
+        blew_up = False
+        error_message = None
+        # Disable the cache
+        try:
+            DISABLE_CACHING.enable()
+            with self.assertNumQueries(2 if self.is_sqlite else 1):
+                data1.name = 'test1a'
+                data1.save()
+        except Exception as err:  # In python 3 err is deleted after this block
+            blew_up = True
+            error_message = err
+        finally:
+            DISABLE_CACHING.disable(invalidate_cache=False)
+        self.assertFalse(blew_up, msg='Unexpected Exception Occurred: {0}'.format(error_message))
+        # Caching enabled without invalidating so this query should
+        # be cached even though the object is no longer named test1.
+        with self.assertNumQueries(0):
+            Test.objects.get(name='test1')
+        with self.assertNumQueries(1):
+            Test.objects.get(name='test1a')
+
+    def test_raw_read_disabling_using_with_stmt(self):
+        with self.assertNumQueries(1):
+            Test.objects.get(name='test1')
+        # Disable the cache
+        with DISABLE_CACHING:
+            with self.assertNumQueries(1):
+                with connection.cursor() as cursor:
+                    cursor.execute("SELECT name FROM cachalot_test where name = %s", ('test1', ))
+                    tuple(cursor.fetchall())
+        # Caching enabled, invalidating has run
+        with self.assertNumQueries(1):
+            Test.objects.get(name='test1')
+
+    def test_raw_read_disabling_without_invalidating_using_with_stmt(self):
+        with self.assertNumQueries(1):
+            Test.objects.get(name='test1')
+        # Disable the cache
+        with self.assertNumQueries(1):
+            with DISABLE_CACHING:
+                DISABLE_CACHING.do_not_invalidate()
+                with connection.cursor() as cursor:
+                    cursor.execute("SELECT name FROM cachalot_test where name = %s", ('test1', ))
+        # Caching enabled, invalidating has run
+        with self.assertNumQueries(0):
+            Test.objects.get(name='test1')
+
+    def test_raw_read_disabling_using_try_finally(self):
+        with self.assertNumQueries(1):
+            Test.objects.get(name='test1')
+        blew_up = False
+        error_message = None
+        # Disable the cache
+        try:
+            with self.assertNumQueries(1):
+                DISABLE_CACHING.enable()
+                with connection.cursor() as cursor:
+                    cursor.execute("SELECT name FROM cachalot_test where name = %s", ('test1', ))
+        except Exception as err:  # In python 3 err is deleted after this block
+            blew_up = True
+            error_message = err
+        finally:
+            DISABLE_CACHING.disable()
+        self.assertFalse(blew_up, msg='Unexpected Exception Occurred: {0}'.format(error_message))
+        # Caching enabled but invalidating has run
+        with self.assertNumQueries(1):
+            Test.objects.get(name='test1')
+
+    def test_raw_read_disabling_without_invalidating_using_try_finally(self):
+        with self.assertNumQueries(1):
+            Test.objects.get(name='test1')
+        blew_up = False
+        error_message = None
+        # Disable the cache
+        try:
+            DISABLE_CACHING.enable()
+            with self.assertNumQueries(1):
+                with connection.cursor() as cursor:
+                    cursor.execute("SELECT name FROM cachalot_test where name = %s", ('test1', ))
+        except Exception as err:  # In python 3 err is deleted after this block
+            blew_up = True
+            error_message = err
+        finally:
+            DISABLE_CACHING.disable(invalidate_cache=False)
+        self.assertFalse(blew_up, msg='Unexpected Exception Occurred: {0}'.format(error_message))
+        # Caching enabled without invalidating so this query should be cached
+        with self.assertNumQueries(0):
+            Test.objects.get(name='test1')
+
+    def test_raw_write_disabling_using_with_stmt(self):
+        with self.assertNumQueries(1):
+            Test.objects.get(name='test1')
+        # Disable the cache
+        with DISABLE_CACHING:
+            with self.assertNumQueries(1):
+                with connection.cursor() as cursor:
+                    cursor.execute("UPDATE cachalot_test set name = %s where name = %s", ('test1a', 'test1'))
+        # Caching enabled, invalidating has run
+        with self.assertRaises(Test.DoesNotExist):
+            Test.objects.get(name='test1')
+        with self.assertNumQueries(1):
+            Test.objects.get(name='test1a')
+
+    def test_raw_write_disabling_without_invalidating_using_with_stmt(self):
+        with self.assertNumQueries(1):
+            Test.objects.get(name='test1')
+        # Disable the cache
+        with DISABLE_CACHING:
+            DISABLE_CACHING.do_not_invalidate()
+            with self.assertNumQueries(1):
+                with connection.cursor() as cursor:
+                    cursor.execute("UPDATE cachalot_test set name = %s where name = %s", ('test1a', 'test1'))
+        # Caching enabled without invalidating so this query should
+        # be cached even though the object is no longer named test1.
+        with self.assertNumQueries(0):
+            Test.objects.get(name='test1')
+        with self.assertNumQueries(1):
+            Test.objects.get(name='test1a')
+
+    def test_raw_write_disabling_using_try_finally(self):
+        with self.assertNumQueries(1):
+            Test.objects.get(name='test1')
         blew_up = False
         err = None
         # Disable the cache
         try:
             DISABLE_CACHING.enable()
             with self.assertNumQueries(1):
-                data1.name = 'test1a'
-                data1.save()
+                with connection.cursor() as cursor:
+                    cursor.execute("UPDATE cachalot_test set name = %s where name = %s", ('test1a', 'test1'))
+        except Exception as err:
+            blew_up = True
+        finally:
+            DISABLE_CACHING.disable()
+        self.assertFalse(blew_up, msg='Unexpected Exception Occurred: {0}'.format(err))
+        # Caching enabled, invalidating has run
+        with self.assertRaises(Test.DoesNotExist):
+            Test.objects.get(name='test1')
+        with self.assertNumQueries(1):
+            Test.objects.get(name='test1a')
+
+    def test_raw_write_disabling_without_invalidating_using_try_finally(self):
+        with self.assertNumQueries(1):
+            Test.objects.get(name='test1')
+        blew_up = False
+        err = None
+        # Disable the cache
+        try:
+            DISABLE_CACHING.enable()
+            with self.assertNumQueries(1):
+                with connection.cursor() as cursor:
+                    cursor.execute("UPDATE cachalot_test set name = %s where name = %s", ('test1a', 'test1'))
         except Exception as err:
             blew_up = True
         finally:
@@ -241,41 +349,6 @@ class DisablingTestCase(TestUtilsMixin, TransactionTestCase):
         # Caching enabled without invalidating so this query should
         # be cached even though the object is no longer named test1.
         with self.assertNumQueries(0):
-            data2 = Test.objects.get(name='test1')
-            data2_name = data2.name  # Force the query to run
+            Test.objects.get(name='test1')
         with self.assertNumQueries(1):
-            data3 = Test.objects.get(name='test1a')
-            data3_name = data3.name  # Force the query to run
-        data1.name = 'test1'
-        data1.save()
-
-    def test_raw_read_toggle_disabling_using_with_stmt(self):
-        with self.assertNumQueries(1):
-            with connection.cursor() as cursor:
-                cursor.execute("SELECT name FROM cachalot_test where name = %s", 'test1')
-        # Disable the cache
-        with DISABLE_CACHING:
-            with self.assertNumQueries(1):
-                with connection.cursor() as cursor:
-                    cursor.execute("SELECT name FROM cachalot_test where name = %s", 'test1')
-        # Caching enabled, invalidating has run
-        with self.assertNumQueries(1):
-            with connection.cursor() as cursor:
-                cursor.execute("SELECT name FROM cachalot_test where name = %s", 'test1')
-        with self.assertNumQueries(0):
-            with connection.cursor() as cursor:
-                cursor.execute("SELECT name FROM cachalot_test where name = %s", 'test1')
-
-    def test_raw_read_toggle_disabling_without_invalidating_using_with_stmt(self):
-        with self.assertNumQueries(1):
-            with connection.cursor() as cursor:
-                cursor.execute("SELECT name FROM cachalot_test where name = %s", 'test1')
-        # Disable the cache
-        with DISABLE_CACHING:
-            with self.assertNumQueries(1):
-                with connection.cursor() as cursor:
-                    cursor.execute("SELECT name FROM cachalot_test where name = %s", 'test1')
-        # Caching enabled, invalidating has run
-        with self.assertNumQueries(0):
-            with connection.cursor() as cursor:
-                cursor.execute("SELECT name FROM cachalot_test where name = %s", 'test1')
+            Test.objects.get(name='test1a')

--- a/cachalot/tests/disabling.py
+++ b/cachalot/tests/disabling.py
@@ -248,3 +248,34 @@ class DisablingTestCase(TestUtilsMixin, TransactionTestCase):
             data3_name = data3.name  # Force the query to run
         data1.name = 'test1'
         data1.save()
+
+    def test_raw_read_toggle_disabling_using_with_stmt(self):
+        with self.assertNumQueries(1):
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT name FROM cachalot_test where name = %s", 'test1')
+        # Disable the cache
+        with DISABLE_CACHING:
+            with self.assertNumQueries(1):
+                with connection.cursor() as cursor:
+                    cursor.execute("SELECT name FROM cachalot_test where name = %s", 'test1')
+        # Caching enabled, invalidating has run
+        with self.assertNumQueries(1):
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT name FROM cachalot_test where name = %s", 'test1')
+        with self.assertNumQueries(0):
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT name FROM cachalot_test where name = %s", 'test1')
+
+    def test_raw_read_toggle_disabling_without_invalidating_using_with_stmt(self):
+        with self.assertNumQueries(1):
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT name FROM cachalot_test where name = %s", 'test1')
+        # Disable the cache
+        with DISABLE_CACHING:
+            with self.assertNumQueries(1):
+                with connection.cursor() as cursor:
+                    cursor.execute("SELECT name FROM cachalot_test where name = %s", 'test1')
+        # Caching enabled, invalidating has run
+        with self.assertNumQueries(0):
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT name FROM cachalot_test where name = %s", 'test1')

--- a/cachalot/tests/disabling.py
+++ b/cachalot/tests/disabling.py
@@ -1,32 +1,17 @@
 # coding: utf-8
 
 from __future__ import unicode_literals
-import datetime
-from unittest import skipIf, skipUnless
-from uuid import UUID
-from decimal import Decimal
+from unittest import skipIf
 
-from django import VERSION as django_version
 from django.conf import settings
 from django.contrib.auth.models import Group, Permission, User
-from django.contrib.contenttypes.models import ContentType
-from django.core.cache import cache
-from django.core.cache import DEFAULT_CACHE_ALIAS, caches
-from django.db import connection, transaction, connections, DEFAULT_DB_ALIAS
-from django.db.models import Count
-from django.db.models.expressions import RawSQL
-from django.db.transaction import TransactionManagementError
-from django.test import (
-    TransactionTestCase, skipUnlessDBFeature, override_settings)
-from pytz import UTC
-
+from django.core.cache import DEFAULT_CACHE_ALIAS
+from django.db import connection, connections, DEFAULT_DB_ALIAS
+from django.test import TransactionTestCase
 from ..api import invalidate
 from ..monkey_patch import DISABLE_CACHING
-from ..settings import cachalot_settings
-from ..utils import UncachableQuery
-from .models import Test, TestChild, TestParent
+from .models import Test
 from .test_utils import TestUtilsMixin
-
 
 
 class DisablingTestCase(TestUtilsMixin, TransactionTestCase):

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -324,3 +324,48 @@ Example:
     def warn_admin(sender, **kwargs):
         mail_admins('User permissions changed',
                     'Someone probably gained or lost Django permissions.')
+
+
+Disabling the cache for a transaction
+....
+
+If you have a long running data import which is mostly inserting and updating data
+or uses a lot of tables that you do not want cached you may find that cachalot can
+slow things down because of the overhead of invalidating and checking if caching should
+occur for each sql statement.  If this is the case you can disable caching for the
+transaction which will make the transaction run faster because of a lower overhead.
+
+Two methods of use exist where you can either use ``with`` or use a ``try: finally:``.
+Each method provides a way to modify the cache and db aliases that are used when
+invalidate is called.  Each method also provides a way to turn off the default
+invalidation in case you want to.
+
+Example 1:
+
+.. code:: python
+
+    from cachalot.monkey_patch import DISABLE_CACHING
+
+    with DISABLE_CACHING:
+        DISABLE_CACHING.do_not_invalidate()  # Only needed if you do not want to invalidate.
+
+        # Optional line that allows you to change the cache and db aliases used when invalidating.
+        DISABLE_CACHING.set_aliases(cache_alias='default', db_alias='default')
+
+        # Code to run while the cache is disabled
+
+Example 2:
+
+.. code:: python
+
+    from cachalot.monkey_patch import DISABLE_CACHING
+
+    try:
+        DISABLE_CACHING.enable()
+
+        # Code to run while the cache is disabled
+
+    finally:
+        # invalidate_cache is only needed if you do not want to invalidate the cache.
+        # Also allow you to change the cache and db aliases used when invalidating.
+        DISABLE_CACHING.disable(invalidate_cache=False, cache_alias='default', db_alias='default'):


### PR DESCRIPTION
Created 3 virtual environments for python 2.7, 3.4, 3.5, and 3.6 and ran the tests on the latests versions of django that you have listed under your requirements. All tests ran successfully.