### PR TITLE
Replace deprecated assignment_tag with simple_tag (Django 2.0 removal)

### DIFF
--- a/cachalot/templatetags/cachalot.py
+++ b/cachalot/templatetags/cachalot.py
@@ -6,4 +6,4 @@ from ..api import get_last_invalidation
 register = Library()
 
 
-register.assignment_tag(get_last_invalidation)
+register.simple_tag(get_last_invalidation)


### PR DESCRIPTION
`assignment_tag` is removed in Django 2.0.  It raises warnings in Django 1.11, but will fail in later versions.  It currently functions as an alias to `simple_tag` anyway.