### PR TITLE
Fix some client returns invalid get_many response

### DIFF
--- a/cachalot/monkey_patch.py
+++ b/cachalot/monkey_patch.py
@@ -41,7 +41,7 @@ def _get_result_or_execute_query(execute_query_func, cache,
     new_table_cache_keys = set(table_cache_keys)
     new_table_cache_keys.difference_update(data)
 
-    if not new_table_cache_keys and cache_key in data:
+    if not new_table_cache_keys and cache_key in data and data[cache_key]:
         timestamp, result = data.pop(cache_key)
         if timestamp >= max(data.values()):
             return result

--- a/cachalot/tests/__init__.py
+++ b/cachalot/tests/__init__.py
@@ -12,6 +12,7 @@ from .api import APITestCase, CommandTestCase
 from .signals import SignalsTestCase
 from .postgres import PostgresReadTestCase
 from .debug_toolbar import DebugToolbarTestCase
+from .monkey_patch import MonkeyPatchTestCase
 
 
 @receiver(setting_changed)

--- a/cachalot/tests/monkey_patch.py
+++ b/cachalot/tests/monkey_patch.py
@@ -1,0 +1,43 @@
+# coding: utf-8
+
+from unittest.mock import patch
+
+from django.core.cache.backends.dummy import DummyCache as DjangoDummyCache
+from django.test import TransactionTestCase
+
+from .models import Test
+from .test_utils import TestUtilsMixin
+
+
+class DummyCache(DjangoDummyCache):
+    def get_many(self, keys):
+        ret = {}
+        for k in keys:
+            ret[k] = False
+
+        return ret
+
+
+class MonkeyPatchTestCase(TestUtilsMixin, TransactionTestCase):
+    def setUp(self):
+        super(MonkeyPatchTestCase, self).setUp()
+
+        self.qs = Test.objects.create(name='test1')
+
+    @patch('cachalot.cache.cachalot_caches.get_cache')
+    def test_cache_get_many_invalid(self, get_cache):
+        get_cache.return_value = DummyCache(host=None, params={})
+
+        # Check DummyCache is response dummy response.
+        from cachalot.cache import cachalot_caches
+        ret = cachalot_caches.get_cache().get_many(['key1'])
+        self.assertEqual(ret, {'key1': False})
+
+        qs = Test.objects.get(name='test1')
+        self.assertTrue(get_cache.called)
+        self.assertEqual(qs.name, self.qs.name)
+
+        Test.objects.create(name='test2')
+        qs = Test.objects.all()
+        for q in qs:
+            self.assertIn(q.name, ['test1', 'test2'])


### PR DESCRIPTION
Some cache client's `get_many` method, e.g [pymemcache](https://github.com/pinterest/pymemcache/blob/v1.4.3/pymemcache/client/hash.py#L279), returns like `[{'key': False}]`.

This cause following TypeError.

```
timestamp, result = data.pop(cache_key)
TypeError: 'bool' object is not iterable
```

So I add check `result` is valid and if invalid value were returned,
ignore and return query result.

Please check this and very pleasure to give me advices.

Regards.