### PR TITLE
django2.0 Library simple_tag instead of assignment_tag

### DIFF
--- a/cachalot/templatetags/cachalot.py
+++ b/cachalot/templatetags/cachalot.py
@@ -6,4 +6,4 @@ from ..api import get_last_invalidation
 register = Library()
 
 
-register.assignment_tag(get_last_invalidation)
+register.simple_tag(get_last_invalidation)


### PR DESCRIPTION
Converted Library()  assignment_tag() to simple_tag from Django 2.0